### PR TITLE
Fix index for addition operator

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
                 = head:mult_expr tail:( _ ("+" / "-") _ mult_expr)* { return function() {
                         var total = head();
                         for (var i = 0; i < tail.length; i++) {
-                            if (tail[i][0] === "+") {
+                            if (tail[i][1] === "+") {
                                 total += tail[i][3]();
                             } else {
                                 total -= tail[i][3]();

--- a/parser.txt
+++ b/parser.txt
@@ -96,7 +96,7 @@ arith_expr
     = head:mult_expr tail:( _ ("+" / "-") _ mult_expr)* { return function() {
             var total = head();
             for (var i = 0; i < tail.length; i++) {
-                if (tail[i][0] === "+") {
+                if (tail[i][1] === "+") {
                     total += tail[i][3]();
                 } else {
                     total -= tail[i][3]();


### PR DESCRIPTION
The following while program will not give the correct result (fixed in this current commit):
```
i := 2;
j := i + 8
```

The interpreter states i = 2 and j = -6. j should be 10. 

This PR fixes this small problem.

Thanks,

Ryan Smith